### PR TITLE
feature: Add suport for building with specified OS/Arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
 VERSION := $(shell git describe --tags)
-AWSLIM_OS ?= $(shell uname -s | tr '[A-Z]' '[a-z]')
-AWSLIM_ARCH ?= $(shell uname -m | sed \
-			   -e 's/^x86_64$$/amd64/' \
-			   -e 's/^aarch64$$/arm64/')
 .PHONY: clean test gen
 
 build: gen awslim

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 VERSION := $(shell git describe --tags)
+AWSLIM_OS ?= $(shell uname -s | tr '[A-Z]' '[a-z]')
+AWSLIM_ARCH ?= $(shell uname -m | sed \
+			   -e 's/^x86_64$$/amd64/' \
+			   -e 's/^aarch64$$/arm64/')
 .PHONY: clean test gen
 
 build: gen awslim
@@ -6,6 +10,8 @@ build: gen awslim
 
 awslim: go.* *.go
 	CGO_ENABLED=0 \
+	GOOS=${AWSLIM_OS} \
+	GOARCH=${AWSLIM_ARCH} \
 		go build -o $@ \
 		-tags netgo \
 		-ldflags '-s -w -extldflags "-static" -X github.com/fujiwara/awslim.Version=$(VERSION)' \

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ services:
 
 Keys under `services` are AWS service names (`github.com/aws/aws-sdk-go-v2/service/*`), and values are method names of the service client (for example, `s3` is [s3.Client](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client)). If you don't specify the method names, all methods of the service client are generated.
 
-### Build biary for specified OS/Architecture
+### Build binary for specified OS/Architecture
 
 Set the `AWSLIM_OS` and `AWSLIM_ARCH` environment variables to specify the OS and architecture for the build.
 If these variables are not set, awslim will build based on the architecture of the build environment.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ services:
 
 Keys under `services` are AWS service names (`github.com/aws/aws-sdk-go-v2/service/*`), and values are method names of the service client (for example, `s3` is [s3.Client](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client)). If you don't specify the method names, all methods of the service client are generated.
 
+### Build biary for specified OS/Architecture
+
+Set the `AWSLIM_OS` and `AWSLIM_ARCH` environment variables to specify the OS and architecture for the build.
+If these variables are not set, awslim will build based on the architecture of the build environment.
+These variables can also be specified when building with Docker.
+The values that can be set for AWSLIM_OS and AWSLIM_ARCH are the same as for GOOS and GOARCH.
+
 ### Build on your machine
 
 To build the client, run the following commands (or simply run `make`):
@@ -99,6 +106,13 @@ Environment variables:
 Example using the `AWSLIM_GEN` environment variable:
 ```console
 $ docker run -it -e AWSLIM_GEN=ecs,firehose,s3 ghcr.io/fujiwara/awslim:builder
+...
+```
+
+Example to specify build for OS and Architecture:
+
+```console
+$ docker run -it -e AWSLIM_GEN=ecs,firehose,s3 -e AWSLIM_OS=linux -e AWSLIM_ARCHI=arm64 ghcr.io/fujiwara/awslim:builder
 ...
 ```
 


### PR DESCRIPTION
## Description

Add support for building with specified OS and architecture.
By specifying the environment variables `AWSLIM_OS` and `AWSLIM_ARCH`, values can be passed to the `GOOS` and `GOARCH` for go build.

## Testing

<details><summary>Build on a local machine with specified OS/Arch</summary>

```shell
$ AWSLIM_GEN="ecs,firehose,s3" AWSLIM_OS=linux AWSLIM_ARCH=amd64 make
go generate ./cmd/awslim-gen .
2024/05/27 13:56:29 generating gen.go
2024/05/27 13:56:29 AWSLIM_GEN is set, generating services: ecs,firehose,s3
2024/05/27 13:56:29 generated gen.go
2024/05/27 13:56:30 generating ecs_gen.go
2024/05/27 13:56:30 no params func Options
2024/05/27 13:56:30 generating ecs_gen.go
2024/05/27 13:56:30 generated ecs_gen.go
2024/05/27 13:56:30 generating firehose_gen.go
2024/05/27 13:56:30 no params func Options
2024/05/27 13:56:30 generating firehose_gen.go
2024/05/27 13:56:30 generated firehose_gen.go
2024/05/27 13:56:30 generating s3_gen.go
2024/05/27 13:56:30 found io.ReadCloser field in s3.GetObjectOutput Body io.ReadCloser
2024/05/27 13:56:30 found io.ReadCloser field in s3.GetObjectTorrentOutput Body io.ReadCloser
2024/05/27 13:56:30 no params func Options
2024/05/27 13:56:30 found io.Reader field in s3.PutObjectInput Body io.Reader
2024/05/27 13:56:30 found ContentLength field in s3.PutObjectInput ContentLength ContentLength
2024/05/27 13:56:30 found io.Reader field in s3.UploadPartInput Body io.Reader
2024/05/27 13:56:30 found ContentLength field in s3.UploadPartInput ContentLength ContentLength
2024/05/27 13:56:30 found io.Reader field in s3.WriteGetObjectResponseInput Body io.Reader
2024/05/27 13:56:30 found ContentLength field in s3.WriteGetObjectResponseInput ContentLength ContentLength
2024/05/27 13:56:30 generating s3_gen.go
2024/05/27 13:56:30 generated s3_gen.go
2024/05/27 13:56:30 generating main_gen.go
2024/05/27 13:56:30 generated main_gen.go
go fmt
ecs_gen.go
firehose_gen.go
main_gen.go
s3_gen.go
CGO_ENABLED=0 \
        GOOS=linux \
        GOARCH=amd64 \
                go build -o awslim \
                -tags netgo \
                -ldflags '-s -w -extldflags "-static" -X github.com/fujiwara/awslim.Version=' \
                cmd/awslim/main.go
$ file awslim
awslim: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=q5u2h8KhgIc0N1uFgfTV/fOIjBfY6-uWapDGNtwiI/03yMncrQwaxQRtc0bBMd/LLS6dur6B1Ryp0d2v8lZ, stripped
```
</details>

<details><summary>Build on a local machine with NOT specified OS/Arch</summary>

```shell
$ uname -ms
Darwin arm64

$ AWSLIM_GEN="ecs,firehose,s3" make build
go generate ./cmd/awslim-gen .
2024/05/27 14:12:41 generating gen.go
2024/05/27 14:12:41 AWSLIM_GEN is set, generating services: ecs,firehose,s3
2024/05/27 14:12:41 generated gen.go
go: added github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2
...
go: added github.com/aws/aws-sdk-go-v2/service/s3 v1.54.3
2024/05/27 14:12:43 generating ecs_gen.go
2024/05/27 14:12:43 no params func Options
2024/05/27 14:12:43 generating ecs_gen.go
2024/05/27 14:12:43 generated ecs_gen.go
2024/05/27 14:12:43 generating firehose_gen.go
2024/05/27 14:12:43 no params func Options
2024/05/27 14:12:43 generating firehose_gen.go
2024/05/27 14:12:43 generated firehose_gen.go
2024/05/27 14:12:43 generating s3_gen.go
2024/05/27 14:12:43 found io.ReadCloser field in s3.GetObjectOutput Body io.ReadCloser
2024/05/27 14:12:43 found io.ReadCloser field in s3.GetObjectTorrentOutput Body io.ReadCloser
2024/05/27 14:12:43 no params func Options
2024/05/27 14:12:43 found io.Reader field in s3.PutObjectInput Body io.Reader
2024/05/27 14:12:43 found ContentLength field in s3.PutObjectInput ContentLength ContentLength
2024/05/27 14:12:43 found io.Reader field in s3.UploadPartInput Body io.Reader
2024/05/27 14:12:43 found ContentLength field in s3.UploadPartInput ContentLength ContentLength
2024/05/27 14:12:43 found io.Reader field in s3.WriteGetObjectResponseInput Body io.Reader
2024/05/27 14:12:43 found ContentLength field in s3.WriteGetObjectResponseInput ContentLength ContentLength
2024/05/27 14:12:43 generating s3_gen.go
2024/05/27 14:12:43 generated s3_gen.go
2024/05/27 14:12:43 generating main_gen.go
2024/05/27 14:12:43 generated main_gen.go
go fmt
ecs_gen.go
firehose_gen.go
main_gen.go
s3_gen.go
CGO_ENABLED=0 \
        GOOS= \
        GOARCH= \
                go build -o awslim \
                -tags netgo \
                -ldflags '-s -w -extldflags "-static" -X github.com/fujiwara/awslim.Version=' \
                cmd/awslim/main.go

$ file awslim
awslim: Mach-O 64-bit executable arm64

$ ./awslim
ecs
firehose
s3
```
</details>

Build test docker image.

```diff
diff --git a/Dockerfile b/Dockerfile
index 85c9870..83e9c77 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.22.3-bookworm AS builder
 WORKDIR /app
-RUN git clone https://github.com/fujiwara/awslim.git .
+RUN git clone -b feature/build-specified-os-arch https://github.com/ToshihitoKon/awslim.git .
 RUN rm -f gen.yaml

 ENTRYPOINT ["./build-in-docker.sh"]
```

```shell
$ docker build . -t awslim-builder
```

<details><summary>Build on a Docker with specified OS/Arch</summary>

```
 % docker run -it -e AWSLIM_GEN=ecs,firehose,s3 -e AWSLIM_OS=darwin -e AWSLIM_ARCH=arm64 awslim-builder
Already up to date.
rm -rf *_gen.go awslim dist/ cmd/awslim-gen/gen.go
go mod tidy
go: downloading github.com/goccy/go-yaml v1.11.3
...
go: downloading gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go generate ./cmd/awslim-gen .
2024/05/27 05:04:12 generating gen.go
2024/05/27 05:04:12 AWSLIM_GEN is set, generating services: ecs,firehose,s3
2024/05/27 05:04:12 generated gen.go
go: downloading github.com/aws/aws-sdk-go-v2/service/firehose v1.28.10
...
go: added github.com/aws/aws-sdk-go-v2/service/s3 v1.54.3
2024/05/27 05:04:19 generating ecs_gen.go
2024/05/27 05:04:19 no params func Options
2024/05/27 05:04:19 generating ecs_gen.go
2024/05/27 05:04:19 generated ecs_gen.go
2024/05/27 05:04:19 generating firehose_gen.go
2024/05/27 05:04:19 no params func Options
2024/05/27 05:04:19 generating firehose_gen.go
2024/05/27 05:04:19 generated firehose_gen.go
2024/05/27 05:04:19 generating s3_gen.go
2024/05/27 05:04:19 found io.ReadCloser field in s3.GetObjectOutput Body io.ReadCloser
2024/05/27 05:04:19 found io.ReadCloser field in s3.GetObjectTorrentOutput Body io.ReadCloser
2024/05/27 05:04:19 no params func Options
2024/05/27 05:04:19 found io.Reader field in s3.PutObjectInput Body io.Reader
2024/05/27 05:04:19 found ContentLength field in s3.PutObjectInput ContentLength ContentLength
2024/05/27 05:04:19 found io.Reader field in s3.UploadPartInput Body io.Reader
2024/05/27 05:04:19 found ContentLength field in s3.UploadPartInput ContentLength ContentLength
2024/05/27 05:04:19 found io.Reader field in s3.WriteGetObjectResponseInput Body io.Reader
2024/05/27 05:04:19 found ContentLength field in s3.WriteGetObjectResponseInput ContentLength ContentLength
2024/05/27 05:04:19 generating s3_gen.go
2024/05/27 05:04:19 generated s3_gen.go
2024/05/27 05:04:19 generating main_gen.go
2024/05/27 05:04:19 generated main_gen.go
go fmt
ecs_gen.go
firehose_gen.go
main_gen.go
s3_gen.go
CGO_ENABLED=0 \
GOOS=darwin \
GOARCH=arm64 \
        go build -o awslim \
        -tags netgo \
        -ldflags '-s -w -extldflags "-static" -X github.com/fujiwara/awslim.Version=' \
        cmd/awslim/main.go
Completed. Please extract /app/awslim from this container!
For example, run the following command:
docker cp $(docker ps -lq):/app/awslim .

$ docker cp $(docker ps -lq):/app/awslim .
Successfully copied 20MB to /Users/kon.toshihito/Documents/github.com/ToshihitoKon/awslim/.

$ file awslim
awslim: Mach-O 64-bit executable arm64

$ ./awslim
ecs
firehose
s3
```
</details>

<details><summary>Build on a Docker with NOT specified OS/Arch</summary>

```shell
 % docker run -it -e AWSLIM_GEN=ecs,firehose,s3 awslim-builder
Already up to date.
rm -rf *_gen.go awslim dist/ cmd/awslim-gen/gen.go
go mod tidy
go: downloading github.com/goccy/go-yaml v1.11.3
...
go: downloading gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go generate ./cmd/awslim-gen .
2024/05/27 05:18:52 generating gen.go
2024/05/27 05:18:52 AWSLIM_GEN is set, generating services: ecs,firehose,s3
2024/05/27 05:18:52 generated gen.go
go: downloading github.com/aws/aws-sdk-go-v2/service/s3 v1.54.3
...
go: added github.com/aws/aws-sdk-go-v2/service/s3 v1.54.3
2024/05/27 05:18:59 generating ecs_gen.go
2024/05/27 05:18:59 no params func Options
2024/05/27 05:18:59 generating ecs_gen.go
2024/05/27 05:18:59 generated ecs_gen.go
2024/05/27 05:18:59 generating firehose_gen.go
2024/05/27 05:18:59 no params func Options
2024/05/27 05:18:59 generating firehose_gen.go
2024/05/27 05:18:59 generated firehose_gen.go
2024/05/27 05:18:59 generating s3_gen.go
2024/05/27 05:18:59 found io.ReadCloser field in s3.GetObjectOutput Body io.ReadCloser
2024/05/27 05:18:59 found io.ReadCloser field in s3.GetObjectTorrentOutput Body io.ReadCloser
2024/05/27 05:18:59 no params func Options
2024/05/27 05:18:59 found io.Reader field in s3.PutObjectInput Body io.Reader
2024/05/27 05:18:59 found ContentLength field in s3.PutObjectInput ContentLength ContentLength
2024/05/27 05:18:59 found io.Reader field in s3.UploadPartInput Body io.Reader
2024/05/27 05:18:59 found ContentLength field in s3.UploadPartInput ContentLength ContentLength
2024/05/27 05:18:59 found io.Reader field in s3.WriteGetObjectResponseInput Body io.Reader
2024/05/27 05:18:59 found ContentLength field in s3.WriteGetObjectResponseInput ContentLength ContentLength
2024/05/27 05:18:59 generating s3_gen.go
2024/05/27 05:18:59 generated s3_gen.go
2024/05/27 05:18:59 generating main_gen.go
2024/05/27 05:18:59 generated main_gen.go
go fmt
ecs_gen.go
firehose_gen.go
main_gen.go
s3_gen.go
CGO_ENABLED=0 \
GOOS= \
GOARCH= \
        go build -o awslim \
        -tags netgo \
        -ldflags '-s -w -extldflags "-static" -X github.com/fujiwara/awslim.Version=' \
        cmd/awslim/main.go
Completed. Please extract /app/awslim from this container!
For example, run the following command:
docker cp $(docker ps -lq):/app/awslim .

$ docker cp $(docker ps -lq):/app/awslim .
Successfully copied 19.1MB to /Users/kon.toshihito/Documents/github.com/ToshihitoKon/awslim/.

$ file awslim
awslim: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=DAtSSkgiL4hTPh7EyXcS/ff19iuUd4Xt8b-1-pHMQ/xn3RJ6-1-_wY2mifIiS2/WyS8Y9Pco3SGMgva5kDm, stripped
```

</details>
