### PR TITLE
Rutime Configurations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,23 @@ $ awslim ecs DescribeClusters help
 See https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ecs#Client.DescribeClusters
 ```
 
+### Runtime Configurations
+
+`awslim` reads the configuration file (`~/.config/awslim/config.(json|jsonnet|yaml|yml)`). The configuration file can contain the following fields:
+
+```yaml
+open: /usr/bin/open
+aliases:
+  whoami: sts get-caller-identity
+  regions: ec2 describe-regions --query Regions[].RegionName
+```
+
+- `open`: The command to open the URL to the documentation.
+- `aliases`: The alias of the cli arguments.
+  For example, `awslim whoami` is equivalent to `awslim sts get-caller-identity`.
+
+`XDG_CONFIG_HOME` environment variable is used for the configuration file path. If `XDG_CONFIG_HOME` is not set, `~/.config` is used.
+
 ## LICENSE
 
 MIT

--- a/config.go
+++ b/config.go
@@ -1,0 +1,93 @@
+package sdkclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/goccy/go-yaml"
+	"github.com/google/go-jsonnet"
+	"github.com/mattn/go-shellwords"
+)
+
+const (
+	configSubdir   = "awslim"
+	configBasename = "config"
+)
+
+type RuntimeConfig struct {
+	Open    string            `json:"open" yaml:"open"`
+	Aliases map[string]*Alias `json:"aliases" yaml:"aliases"`
+}
+
+type Alias string
+
+func (a *Alias) Parse() ([]string, error) {
+	return shellwords.Parse(string(*a))
+}
+
+func RuntimeConfigDir() string {
+	if h := os.Getenv("XDG_CONFIG_HOME"); h != "" {
+		return filepath.Join(h, configSubdir)
+	} else {
+		d, err := os.UserHomeDir()
+		if err != nil {
+			d = os.Getenv("HOME")
+		}
+		return filepath.Join(d, ".config", configSubdir)
+	}
+}
+
+func loadRuntimeConfig() (*RuntimeConfig, error) {
+	dir := RuntimeConfigDir()
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return &RuntimeConfig{}, nil
+		}
+		return nil, err
+	}
+	var out RuntimeConfig
+	var found bool
+	for _, ext := range []string{"jsonnet", "yaml", "yml", "json"} {
+		f := filepath.Join(dir, configBasename+"."+ext)
+		if _, err := os.Stat(f); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		slog.Debug(fmt.Sprintf("loading config file: %s", f))
+		switch ext {
+		case "jsonnet", "json":
+			vm := jsonnet.MakeVM()
+			b, err := vm.EvaluateFile(f)
+			if err != nil {
+				return nil, err
+			}
+			if found {
+				slog.Warn(fmt.Sprintf("found multiple config files, ignoring %s", f))
+			} else {
+				if err := json.Unmarshal([]byte(b), &out); err != nil {
+					return nil, err
+				}
+				found = true
+			}
+		case "yaml", "yml":
+			b, err := os.ReadFile(f)
+			if err != nil {
+				return nil, err
+			}
+			if found {
+				slog.Warn(fmt.Sprintf("found multiple config files, ignoring %s", f))
+			} else {
+				if err := yaml.Unmarshal(b, &out); err != nil {
+					return nil, err
+				}
+				found = true
+			}
+		}
+	}
+	return &out, nil
+}

--- a/gen.yaml
+++ b/gen.yaml
@@ -1,4 +1,5 @@
 services:
+  sts:
   ecs:
     - DescribeClusters
     - DescribeTasks
@@ -24,3 +25,5 @@ services:
     - SelectObjectContent
     - UploadPart
     - UploadPartCopy
+  ec2:
+    - DescribeRegions

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-jsonnet v0.20.0
 	github.com/jmespath/go-jmespath v0.4.0
+	github.com/mattn/go-shellwords v1.0.12
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func (c *CLI) CallMethod(ctx context.Context) error {
 func (c *CLI) showHelp(key string) {
 	u := fmt.Sprintf("https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/%s", key)
 	fmt.Fprintf(c.w, "See %s\n", u)
-	if c.rc.Open != "" {
+	if c.rc != nil && c.rc.Open != "" {
 		slog.Info("run open command", "url", u)
 		if err := exec.Command(c.rc.Open, u).Run(); err != nil {
 			slog.Error("failed to open command", "error", err)

--- a/param.go
+++ b/param.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -30,7 +30,7 @@ type clientMethodParam struct {
 func (p *clientMethodParam) Cleanup() {
 	for _, f := range p.cleanup {
 		if err := f(); err != nil {
-			log.Printf("[warn] failed to cleanup: %v", err)
+			slog.Warn("failed to cleanup: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
### Runtime Configurations

`awslim` reads the configuration file (`~/.config/awslim/config.(json|jsonnet|yaml|yml)`). The configuration file can contain the following fields:

```yaml
open: /usr/bin/open
aliases:
  whoami: sts get-caller-identity
  regions: ec2 describe-regions --query Regions[].RegionName
```

- `open`: The command to open the URL to the documentation.
- `aliases`: The alias of the cli arguments.
  For example, `awslim whoami` is equivalent to `awslim sts get-caller-identity`.

`XDG_CONFIG_HOME` environment variable is used for the configuration file path. If `XDG_CONFIG_HOME` is not set, `~/.config` is used.
