### PR TITLE
Accept dynamic flags!

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ $ awslim ecs
 The third argument is a [JSON](https://json.org) or [Jsonnet](https://jsonnet.org/) input for the method. This can be omitted if the method requires no input (`{}` is passed implicitly).
 
 ```console
-$ awslim lambda ListTasks '{Cluster:"default"}'   # JSON
+$ awslim ecs ListTasks '{Cluster:"default"}'   # JSON
 
-$ awslim lambda ListTasks '{Cluster:"default"}'   # Jsonnet
+$ awslim ecs ListTasks '{Cluster:"default"}'   # Jsonnet
 ```
 
 If the method name is "kebab-case", it automatically converts to "PascalCase" (i.e., `list-tasks` -> `ListTasks`).
@@ -252,11 +252,11 @@ $ awslim ecs list-tasks input.jsonnet
 awslim supports Jsonnet functions for the input JSON.
 
 ```console
-$ awslim ecs describe-clusters '{Cluster: _(0)}' foo
+$ awslim ecs list-tasks '{Cluster: _(0)}' foo
 
-$ CLUSTER=foo awslim ecs describe-clusters '{Cluster: env("CLUSTER","default")}'
+$ CLUSTER=foo awslim ecs list-tasks '{Cluster: env("CLUSTER","default")}'
 
-$ CLUSTER=foo awslim ecs describe-clusters '{Cluster: must_env("CLUSTER")}'
+$ CLUSTER=foo awslim ecs list-tasks '{Cluster: must_env("CLUSTER")}'
 ```
 
 - `_(n)` returns the n-th argument.
@@ -281,7 +281,7 @@ Pass external variables to Jsonnet.
 This is useful when you want to use variables in Jsonnet.
 
 ```console
-$ awslim ecs DescribeClusters my.jsonnet --ext-str Cluster=default
+$ awslim ecs list-tasks my.jsonnet --ext-str Cluster=default
 ```
 
 ```jsonnet
@@ -296,7 +296,7 @@ $ awslim ecs DescribeClusters my.jsonnet --ext-str Cluster=default
 Bind a file or stdin to the input struct.
 
 ```console
-$ awslim s3 put-object '{"Bucket": "my-bucket", "Key": "my.txt"}' --input-stream my.txt
+$ awslim s3 put-object '{Bucket:"my-bucket",Key:"my.txt"}' --input-stream my.txt
 ```
 
 [s3#PutObjectInput](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#PutObjectInput) has `Body` field of `io.Reader`. `--input-stream` option binds the file to the field.
@@ -312,7 +312,7 @@ If `--input-stream` is "-", `awslim` reads from stdin. In this case, `awslim` re
 Bind the `io.ReadCloser` of the API output to a file or stdout.
 
 ```console
-$ awslim s3 get-object '{"Bucket": "my-bucket", "Key": "my.txt"}' --output-stream my.txt
+$ awslim s3 get-object '{Bucket:"my-bucket",Key:"my.txt"}' --output-stream my.txt
 ```
 
 [s3#GetObjectOutput](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#PutObjectOutput) has `Body` field of `io.ReadeCloser`. `--output-stream` option binds the file to the field.
@@ -336,14 +336,14 @@ For example, [s3#ListObjectsV2Output](https://pkg.go.dev/github.com/aws/aws-sdk-
 `{FieldInOutput}={FieldInInput}` format is used for `--follow-next` option.
 
 ```console
-$ awslim s3 list-objects-v2 '{"Bucket": "my-bucket"}' \
+$ awslim s3 list-objects-v2 '{Bucket:"my-bucket"}' \
   --follow-next NextContinuationToken=ContinuationToken
 ```
 
 If the same field name is used in the output and input, you can omit the input field name.
 
 ```console
-$ awslim ecs list-tasks '{"Cluster":"default"}' \
+$ awslim ecs list-tasks '{Cluster:"default"}' \
   --follow-next NextToken
 ```
 
@@ -390,8 +390,8 @@ It is not guaranteed that the results will match those in the AWS CLI output.
 Query the output by JMESPath like the AWS CLI.
 
 ```console
-$ awslim ecs DescribeClusters '{"Cluster":"default"}' \
-  --query 'Clusters[0].ClusterArn'
+$ awslim sts get-caller-identity --query 'Account'
+"012345678901"
 ```
 
 #### Show help

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ If the method name is "kebab-case", it automatically converts to "PascalCase" (i
 $ awslim ecs list-tasks '{Cluster:"default"}'
 ```
 
-In v0.3.0, flag arguments can be specified like as the AWS CLI!
+In v0.3.0, flag arguments can be specified, like the AWS CLI!
 
 ```console
 $ awslim ecs list-tasks --cluster default

--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,57 @@
+package sdkclient
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kong"
+)
+
+func flagExists(k *kong.Kong, flagName string) bool {
+	for _, flagSet := range k.Model.AllFlags(false) {
+		for _, f := range flagSet {
+			if f.Name == flagName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func parseDynamicFlags(k *kong.Kong, args []string, convert func(string) string) ([]string, map[string]any, error) {
+	if convert == nil {
+		convert = func(s string) string { return s }
+	}
+	dynamicFlags := make(map[string]any)
+	rArgs := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		if !strings.HasPrefix(arg, "--") {
+			rArgs = append(rArgs, arg)
+			continue
+		}
+		parts := strings.SplitN(arg, "=", 2)
+		name := strings.TrimPrefix(parts[0], "--")
+		if flagExists(k, name) {
+			rArgs = append(rArgs, arg)
+			continue
+		}
+		if len(parts) == 2 {
+			// --flag=value
+			dynamicFlags[convert(name)] = parts[1]
+		} else {
+			// --flag value
+			// read next arg as value
+			if i+1 < len(args) {
+				dynamicFlags[convert(name)] = args[i+1]
+				i++
+			} else {
+				return nil, nil, fmt.Errorf("flag %s requires a value", arg)
+			}
+		}
+	}
+	return rArgs, dynamicFlags, nil
+}

--- a/param.go
+++ b/param.go
@@ -54,6 +54,22 @@ func (p *clientMethodParam) Validate(name, inputReaderField, outputReadCloserFie
 	return nil
 }
 
+func (p *clientMethodParam) InjectMap(in map[string]any) error {
+	v := make(map[string]any)
+	if err := json.Unmarshal(p.InputBytes, &v); err != nil {
+		return fmt.Errorf("failed to unmarshal %s: %w", p.InputBytes, err)
+	}
+	for field, value := range in {
+		v[field] = value
+	}
+	if b, err := json.Marshal(v); err != nil {
+		return fmt.Errorf("failed to marshal %v: %w", v, err)
+	} else {
+		p.InputBytes = b
+	}
+	return nil
+}
+
 func (p *clientMethodParam) Inject(field string, value any) error {
 	v := make(map[string]any)
 	if err := json.Unmarshal(p.InputBytes, &v); err != nil {


### PR DESCRIPTION
Flag arguments can be specified, like the AWS CLI!

```console
$ awslim ecs list-tasks --cluster default
```

**Note**: Currently, flag arguments do not support setting non-string fields (array, object, number, and boolean). Use JSON or Jsonnet for such fields.

```console
$ awslim ecs list-tasks '{MaxResults:10}' --cluster default
```
