### PR TITLE
Add client options support and environment variable flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Flags:
       --[no-]strict               strict input JSON unmarshaling
   -f, --follow-next=""            OutputField=InputField format. follow the next token.
       --camel                     convert keys to camelCase
+  -C, --client-option=STRING      client options JSON/Jsonnet struct or filename (e.g. '{UsePathStyle: true}')
   -n, --dry-run                   dry-run mode
   -v, --version                   show version
       --debug                     turn on debug logging
@@ -196,6 +197,8 @@ Flags:
 - `input`: JSON input for the method.
 
 The output is JSON format.
+
+All flags can also be set by environment variables prefixed with `AWSLIM_` (e.g., `AWSLIM_COMPACT=true`, `AWSLIM_CLIENT_OPTION='{"UsePathStyle":true}'`).
 
 ### Example usage
 
@@ -385,6 +388,21 @@ This conversion is performed mechanically, so objects for which any key can be s
 
 It is not guaranteed that the results will match those in the AWS CLI output.
 
+#### `--client-option (-C)` option
+
+`--client-option` sets the options of the service client (`Options` struct of the service package, e.g. [s3.Options](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Options)). The value is a JSON/Jsonnet struct or a filename, same as the input.
+
+For example, to access an S3 compatible storage (e.g. MinIO) with path-style URLs:
+
+```console
+$ awslim s3 list-objects-v2 '{Bucket: "mybucket"}' \
+    -C '{UsePathStyle: true, BaseEndpoint: "http://localhost:9000"}'
+```
+
+The keys are the field names of the `Options` struct. Only fields which can be unmarshaled from JSON (e.g. `bool`, `string`, `int`) are supported. Fields of function or interface types (e.g. `HTTPClient`, `EndpointResolverV2`, `APIOptions`) cannot be set. Unknown fields cause an error unless `--no-strict` is specified.
+
+The client options can also be defined per service in the [runtime configuration file](#runtime-configurations). Options specified by `--client-option` override the options in the configuration file.
+
 #### Query output by JMESPath
 
 Query the output by JMESPath like the AWS CLI.
@@ -412,11 +430,16 @@ open: /usr/bin/open
 aliases:
   whoami: sts get-caller-identity
   regions: ec2 describe-regions --query Regions[].RegionName
+client_options:
+  s3:
+    UsePathStyle: true
+    BaseEndpoint: http://localhost:9000
 ```
 
 - `open`: The command to open the URL to the documentation.
 - `aliases`: The alias of the cli arguments.
   For example, `awslim whoami` is equivalent to `awslim sts get-caller-identity`.
+- `client_options`: The default client options for each service. See [`--client-option`](#--client-option--c-option).
 
 `XDG_CONFIG_HOME` environment variable is used for the configuration file path. If `XDG_CONFIG_HOME` is not set, `~/.config` is used.
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -13,6 +13,15 @@ type PagingOutput struct {
 	Next string `json:"Next,omitempty"`
 }
 
+// MockOptions mimics a service client Options struct (e.g. s3.Options).
+type MockOptions struct {
+	Region           string
+	BaseEndpoint     *string
+	UsePathStyle     bool
+	RetryMaxAttempts int
+	HTTPClient       any
+}
+
 func init() {
 	sdkclient.SetClientMethod("foo", "List", func(_ context.Context, _ *sdkclient.ClientMethodParam) (any, error) {
 		return []string{"a", "b", "c"}, nil
@@ -30,6 +39,26 @@ func init() {
 		var v any
 		err := json.Unmarshal(p.InputBytes, &v)
 		return v, err
+	})
+	sdkclient.SetClientMethod("baz", "Options", func(_ context.Context, p *sdkclient.ClientMethodParam) (any, error) {
+		o := MockOptions{Region: "default-region"}
+		if err := p.ApplyClientOptions(&o); err != nil {
+			return nil, err
+		}
+		if p.DryRun {
+			return nil, sdkclient.ErrDryRun
+		}
+		return o, nil
+	})
+	sdkclient.SetClientMethod("foo", "Options", func(_ context.Context, p *sdkclient.ClientMethodParam) (any, error) {
+		o := MockOptions{Region: "default-region"}
+		if err := p.ApplyClientOptions(&o); err != nil {
+			return nil, err
+		}
+		if p.DryRun {
+			return nil, sdkclient.ErrDryRun
+		}
+		return o, nil
 	})
 	sdkclient.SetClientMethod("baz", "Paging", func(_ context.Context, p *sdkclient.ClientMethodParam) (any, error) {
 		var v map[string]string
@@ -63,7 +92,7 @@ var TestCases = []TestCase{
 	{
 		Name:   "list methods of foo",
 		Args:   []string{"foo"},
-		Expect: "Get\nList\n",
+		Expect: "Get\nList\nOptions\n",
 	},
 	{
 		Name:   "list methods of bar",
@@ -73,7 +102,7 @@ var TestCases = []TestCase{
 	{
 		Name:   "list methods of baz",
 		Args:   []string{"baz"},
-		Expect: "Echo\nPaging\n",
+		Expect: "Echo\nOptions\nPaging\n",
 	},
 	{
 		Name:   "call foo#Client.List",
@@ -162,6 +191,59 @@ var TestCases = []TestCase{
 		Name:   "call baz#Client.Echo with dynamic flags",
 		Args:   []string{"baz", "Echo", "--foo-Foo", "FOO", `{Baz:"baz"}`, "-c", "--bar=BAR"},
 		Expect: `{"Bar":"BAR","Baz":"baz","FooFoo":"FOO"}`,
+	},
+	{
+		Name:   "client options from config",
+		Args:   []string{"baz", "Options", "{}", "-c"},
+		Expect: `{"Region":"default-region","BaseEndpoint":"http://localhost:9000","UsePathStyle":true,"RetryMaxAttempts":0,"HTTPClient":null}`,
+	},
+	{
+		Name:   "client options not defined in config",
+		Args:   []string{"foo", "Options", "{}", "-c"},
+		Expect: `{"Region":"default-region","BaseEndpoint":null,"UsePathStyle":false,"RetryMaxAttempts":0,"HTTPClient":null}`,
+	},
+	{
+		Name:   "client options by flag (Jsonnet)",
+		Args:   []string{"foo", "Options", "{}", "-c", "-C", `{UsePathStyle: true, RetryMaxAttempts: 1+2}`},
+		Expect: `{"Region":"default-region","BaseEndpoint":null,"UsePathStyle":true,"RetryMaxAttempts":3,"HTTPClient":null}`,
+	},
+	{
+		Name:   "client options by flag overrides config",
+		Args:   []string{"baz", "Options", "{}", "-c", "--client-option", `{UsePathStyle: false, Region: "ap-northeast-1"}`},
+		Expect: `{"Region":"ap-northeast-1","BaseEndpoint":"http://localhost:9000","UsePathStyle":false,"RetryMaxAttempts":0,"HTTPClient":null}`,
+	},
+	{
+		Name:   "client options by env",
+		Args:   []string{"foo", "Options", "{}", "-c"},
+		Env:    map[string]string{"AWSLIM_CLIENT_OPTION": `{"UsePathStyle": true}`},
+		Expect: `{"Region":"default-region","BaseEndpoint":null,"UsePathStyle":true,"RetryMaxAttempts":0,"HTTPClient":null}`,
+	},
+	{
+		Name:    "client options unknown field (strict)",
+		Args:    []string{"foo", "Options", "{}", "-c", "-C", `{Unknown: true}`},
+		Expect:  "See https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/foo#Options\n",
+		IsError: true,
+	},
+	{
+		Name:   "client options unknown field (no-strict)",
+		Args:   []string{"foo", "Options", "{}", "-c", "--no-strict", "-C", `{Unknown: true, UsePathStyle: true}`},
+		Expect: `{"Region":"default-region","BaseEndpoint":null,"UsePathStyle":true,"RetryMaxAttempts":0,"HTTPClient":null}`,
+	},
+	{
+		Name:   "call baz#Client.Echo --no-strict is not a dynamic flag",
+		Args:   []string{"baz", "Echo", `{Baz:"baz"}`, "-c", "--no-strict"},
+		Expect: `{"Baz":"baz"}`,
+	},
+	{
+		Name:   "flag by env (compact)",
+		Args:   []string{"foo", "List"},
+		Env:    map[string]string{"AWSLIM_COMPACT": "true"},
+		Expect: `["a","b","c"]`,
+	},
+	{
+		Name:   "dry-run shows client options",
+		Args:   []string{"foo", "Options", `{}`, "-n", "-C", `{"UsePathStyle":true}`},
+		Expect: "dry-run: foo#Client.Options will be called with:\n{}\nclient options:\n{\"UsePathStyle\":true}\n",
 	},
 }
 

--- a/cmd/awslim-gen/main.go
+++ b/cmd/awslim-gen/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"text/template"
 )
@@ -24,7 +25,13 @@ import (
 
 {{ range .Methods }}
 func {{ $.PkgName }}_{{ .Name }}(ctx context.Context, p *clientMethodParam) (any, error) {
-	svc := {{ $.PkgName }}.NewFromConfig(p.awsCfg)
+	var optErr error
+	svc := {{ $.PkgName }}.NewFromConfig(p.awsCfg, func(o *{{ $.PkgName }}.Options) {
+		optErr = p.ApplyClientOptions(o)
+	})
+	if optErr != nil {
+		return nil, optErr
+	}
 	var in {{ .Input }}
 	{{- if .InputReaderLengthField }}
 	if err := p.Inject("{{ .InputReaderLengthField }}", p.InputReaderLength); err != nil {
@@ -161,7 +168,7 @@ func gen(pkgName string, clientType reflect.Type, genNames []string) error {
 		return nil
 	}
 	generatedServices = append(generatedServices, pkgName)
-	data := map[string]interface{}{
+	data := map[string]any{
 		"PkgName": pkgName,
 		"Methods": methods,
 	}
@@ -169,12 +176,7 @@ func gen(pkgName string, clientType reflect.Type, genNames []string) error {
 }
 
 func contains(ss []string, s string) bool {
-	for _, v := range ss {
-		if v == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(ss, s)
 }
 
 func writeTemplate(t string, v any, name string) error {

--- a/config.go
+++ b/config.go
@@ -18,8 +18,17 @@ const (
 )
 
 type RuntimeConfig struct {
-	Open    string           `json:"open" yaml:"open"`
-	Aliases map[string]Alias `json:"aliases" yaml:"aliases"`
+	Open          string                    `json:"open" yaml:"open"`
+	Aliases       map[string]Alias          `json:"aliases" yaml:"aliases"`
+	ClientOptions map[string]map[string]any `json:"client_options" yaml:"client_options"`
+}
+
+// clientOptionsFor returns the client options for the service defined in the config.
+func (rc *RuntimeConfig) clientOptionsFor(service string) map[string]any {
+	if rc == nil || rc.ClientOptions == nil {
+		return nil
+	}
+	return rc.ClientOptions[service]
 }
 
 type Alias string

--- a/flags.go
+++ b/flags.go
@@ -13,9 +13,25 @@ func flagExists(k *kong.Kong, flagName string) bool {
 			if f.Name == flagName {
 				return true
 			}
+			if negatedFlagName(f) == flagName {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+// negatedFlagName returns the negated name of a negatable flag (e.g. "no-strict" for "strict").
+// It returns "" if the flag is not negatable.
+func negatedFlagName(f *kong.Flag) string {
+	switch neg := f.Tag.Negatable; neg {
+	case "":
+		return ""
+	case "_": // kong's placeholder for the default "no-" prefix
+		return "no-" + f.Name
+	default:
+		return neg
+	}
 }
 
 func parseDynamicFlags(k *kong.Kong, args []string, convert func(string) string) ([]string, map[string]any, error) {

--- a/main.go
+++ b/main.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"os/exec"
 	"slices"
@@ -36,6 +38,14 @@ type ClientMethod func(context.Context, *clientMethodParam) (any, error)
 
 var ErrDryRun = fmt.Errorf("dry-run mode")
 
+// clientOptionsError is returned when client options cannot be applied to the service client.
+type clientOptionsError struct {
+	err error
+}
+
+func (e *clientOptionsError) Error() string { return e.err.Error() }
+func (e *clientOptionsError) Unwrap() error { return e.err }
+
 type CLI struct {
 	Service string   `arg:"" help:"service name" default:""`
 	Method  string   `arg:"" help:"method name" default:""`
@@ -50,9 +60,10 @@ type CLI struct {
 	Query        string            `short:"q" help:"JMESPath query to apply to output"`
 	ExtStr       map[string]string `help:"external variables for Jsonnet"`
 	ExtCode      map[string]string `help:"external code for Jsonnet"`
-	Strict       bool              `name:"strict" help:"strict input JSON unmarshaling" default:"true" negatable:"true"`
+	Strict       bool              `name:"strict" help:"strict input JSON unmarshaling" default:"true" negatable:""`
 	FollowNext   string            `short:"f" help:"OutputField=InputField format. follow the next token." default:""`
 	CamelCase    bool              `name:"camel" help:"convert keys to camelCase"`
+	ClientOption string            `short:"C" help:"client options JSON/Jsonnet struct or filename (e.g. '{UsePathStyle: true}')"`
 
 	DryRun  bool `short:"n" help:"dry-run mode"`
 	Version bool `short:"v" help:"show version"`
@@ -96,7 +107,7 @@ func NewCLI(ctx context.Context, args []string) (*CLI, error) {
 	}
 	slog.Debug("resolved args", "args", args)
 
-	k, err := kong.New(&c, kong.Vars{"version": Version})
+	k, err := kong.New(&c, kong.Vars{"version": Version}, kong.DefaultEnvars("AWSLIM"))
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +169,15 @@ func (c *CLI) CallMethod(ctx context.Context) error {
 		if err != nil {
 			if err == ErrDryRun {
 				fmt.Fprintf(c.w, "dry-run: %s will be called with:\n%s", key, string(p.InputBytes))
+				if len(p.ClientOptions) > 0 {
+					fmt.Fprintf(c.w, "\nclient options:\n%s\n", string(p.ClientOptions))
+				}
 				return nil
+			}
+			var coe *clientOptionsError
+			if errors.As(err, &coe) {
+				c.showHelp(c.Service + "#Options")
+				return err
 			} else if strings.Contains(err.Error(), "json: unknown field") {
 				c.showHelp(key)
 				return err
@@ -227,7 +246,40 @@ func (c *CLI) output(_ context.Context, out any) error {
 	return nil
 }
 
-func (c *CLI) loadInput(_ context.Context) ([]byte, error) {
+func (c *CLI) loadInput(ctx context.Context) ([]byte, error) {
+	return c.evaluateJsonnet(ctx, c.Input)
+}
+
+// loadClientOptions merges client options from the runtime config (per service)
+// and the --client-option flag. The flag takes precedence over the config.
+func (c *CLI) loadClientOptions(ctx context.Context) (json.RawMessage, error) {
+	merged := make(map[string]any)
+	maps.Copy(merged, c.rc.clientOptionsFor(c.Service))
+	if c.ClientOption != "" {
+		b, err := c.evaluateJsonnet(ctx, c.ClientOption)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client options: %w", err)
+		}
+		var v map[string]any
+		if err := json.Unmarshal(b, &v); err != nil {
+			return nil, fmt.Errorf("failed to load client options: %w", err)
+		}
+		maps.Copy(merged, v)
+	}
+	if len(merged) == 0 {
+		return nil, nil
+	}
+	b, err := json.Marshal(merged)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal client options: %w", err)
+	}
+	slog.Debug("client options", "service", c.Service, "options", string(b))
+	return b, nil
+}
+
+// evaluateJsonnet evaluates src as a JSON/Jsonnet snippet (if it starts with "{")
+// or as a filename, and returns the resulting JSON.
+func (c *CLI) evaluateJsonnet(_ context.Context, src string) ([]byte, error) {
 	var input []byte
 	vm := jsonnet.MakeVM()
 	for k, v := range c.ExtStr {
@@ -237,9 +289,9 @@ func (c *CLI) loadInput(_ context.Context) ([]byte, error) {
 		vm.ExtCode(k, v)
 	}
 	def := c.setNativeFuncs(vm)
-	if strings.HasPrefix(c.Input, "{") {
+	if strings.HasPrefix(src, "{") {
 		// string is JSON or Jsonnet
-		in := def + c.Input
+		in := def + src
 		slog.Debug("evaluate Jsonnet", "input", in)
 		s, err := vm.EvaluateAnonymousSnippet("input", in)
 		if err != nil {
@@ -248,7 +300,7 @@ func (c *CLI) loadInput(_ context.Context) ([]byte, error) {
 		input = []byte(s)
 	} else {
 		// string is filename
-		s, err := vm.EvaluateFile(c.Input)
+		s, err := vm.EvaluateFile(src)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate Jsonnet: %w", err)
 		}
@@ -266,14 +318,19 @@ func (c *CLI) clientMethodParam(ctx context.Context) (*clientMethodParam, error)
 	if err != nil {
 		return nil, err
 	}
+	clientOptions, err := c.loadClientOptions(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	p := &clientMethodParam{
-		awsCfg:       awsCfg,
-		InputBytes:   input,
-		InputReader:  nil,
-		OutputWriter: nil,
-		DryRun:       c.DryRun,
-		Strict:       c.Strict,
+		awsCfg:        awsCfg,
+		ClientOptions: clientOptions,
+		InputBytes:    input,
+		InputReader:   nil,
+		OutputWriter:  nil,
+		DryRun:        c.DryRun,
+		Strict:        c.Strict,
 	}
 	p.SetNextToken(c.FollowNext)
 

--- a/param.go
+++ b/param.go
@@ -24,8 +24,21 @@ type clientMethodParam struct {
 		OutputField string
 		InputField  string
 	}
-	awsCfg  aws.Config
-	cleanup []func() error
+	ClientOptions json.RawMessage
+	awsCfg        aws.Config
+	cleanup       []func() error
+}
+
+// ApplyClientOptions unmarshals ClientOptions (JSON) into o.
+// o must be a pointer to the service client Options struct (e.g. *s3.Options).
+func (p *clientMethodParam) ApplyClientOptions(o any) error {
+	if len(p.ClientOptions) == 0 {
+		return nil
+	}
+	if err := UnmarshalJSON(p.ClientOptions, o, p.Strict); err != nil {
+		return &clientOptionsError{err: fmt.Errorf("failed to apply client options: %w", err)}
+	}
+	return nil
 }
 
 func (p *clientMethodParam) Cleanup() {

--- a/testdata/awslim/config.yaml
+++ b/testdata/awslim/config.yaml
@@ -1,0 +1,4 @@
+client_options:
+  baz:
+    UsePathStyle: true
+    BaseEndpoint: http://localhost:9000


### PR DESCRIPTION
## What

- Add `--client-option` (`-C`) flag and `client_options` in the runtime config to set service client `Options` (e.g. `s3.Options.UsePathStyle`, `BaseEndpoint`). Values are JSON/Jsonnet, unmarshaled into the `Options` struct inside `NewFromConfig` optFns in the generated code. Flag values override config values; unknown fields error under `--strict` and show the `pkg.go.dev/.../{service}#Options` URL.
- Enable `kong.DefaultEnvars("AWSLIM")` so every flag can be set via `AWSLIM_*` environment variables (e.g. `AWSLIM_CLIENT_OPTION`).
- Fix `--no-strict`: `negatable:"true"` made kong's negated flag name `--true`, so `--no-strict` was consumed as a dynamic flag. Use the default negation and make `flagExists` recognize negated names.
- Add `testdata/awslim/config.yaml` (tests already pointed `XDG_CONFIG_HOME` there but the directory did not exist).

## Why

There was no way to change client options such as `UsePathStyle`, which is required for S3-compatible storages (MinIO, etc.). Setting them per service in the config file keeps commands short.

Example:

```console
$ awslim s3 list-objects-v2 '{Bucket: "mybucket"}' -C '{UsePathStyle: true, BaseEndpoint: "http://localhost:9000"}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoooxNoa1L78HiiYGDLPKW
