### PR TITLE
Categorize release notes by labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,19 @@ changelog:
   exclude:
     labels:
       - tagpr
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - major
+    - title: 🚀 New Features
+      labels:
+        - minor
+    - title: ☁️ AWS Service Updates
+      labels:
+        - aws-services
+    - title: 📦 Dependency Updates
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/check-sdk-updates.yml
+++ b/.github/workflows/check-sdk-updates.yml
@@ -78,7 +78,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git commit -m "${PR_TITLE}"
           git push --set-upstream origin "${BRANCH_NAME}"
-          gh pr create --title "${PR_TITLE}" --body "${PR_BODY}" --base main
+          gh pr create --title "${PR_TITLE}" --body "${PR_BODY}" --base main --label aws-services
       - name: make all services
         if: ${{ steps.check-sdk.outputs.updated == 'true' }}
         run: |


### PR DESCRIPTION
## What

- Add categories to `.github/release.yml`: 💥 Breaking Changes (`major`), 🚀 New Features (`minor`), ☁️ AWS Service Updates (`aws-services`), 📦 Dependency Updates (`dependencies`), and Other Changes.
- Label PRs created by `check-sdk-updates.yml` with `aws-services`.
- Created the `major` and `aws-services` labels in the repository.

## Why

The release notes currently list daily AWS service list updates and dependabot bumps together with actual changes, making them hard to read. Following the structure used in sacloud/sacloud-sdk-go, changes are grouped by labels that already drive tagpr version bumps (`major` / `minor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoooxNoa1L78HiiYGDLPKW