### PR TITLE
Use tagpr:major/tagpr:minor labels for version bumps

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,10 +5,10 @@ changelog:
   categories:
     - title: 💥 Breaking Changes
       labels:
-        - major
+        - tagpr:major
     - title: 🚀 New Features
       labels:
-        - minor
+        - tagpr:minor
     - title: ☁️ AWS Service Updates
       labels:
         - aws-services

--- a/.tagpr
+++ b/.tagpr
@@ -41,3 +41,5 @@
 	releaseBranch = main
 	versionFile = -
 	release = draft
+	majorLabels = tagpr:major
+	minorLabels = tagpr:minor


### PR DESCRIPTION
## What

- Configure tagpr with `majorLabels = tagpr:major` and `minorLabels = tagpr:minor`.
- Use those labels in `.github/release.yml` categories.
- Created the `tagpr:major` label and deleted the `major` / `minor` labels from the repository.

## Why

Dependabot automatically adds `major` / `minor` / `patch` labels to its PRs when labels with those names exist. This collided with tagpr's default bump labels (dependency bumps showed up as New Features, and a major dependency bump could trigger a major release). Prefixed labels are not touched by dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoooxNoa1L78HiiYGDLPKW