### PR TITLE
Support Go 1.26 and 1.27

### DIFF
--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.27"
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "1.26"
+          go-version: "1.27"
         if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
 
       - name: setup for all services

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.25'
           - '1.26'
+          - '1.27'
     name: Build
     runs-on: ubuntu-latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-bookworm AS builder
+FROM golang:1.27-bookworm AS builder
 WORKDIR /app
 RUN git clone https://github.com/fujiwara/awslim.git .
 RUN rm -f gen.yaml


### PR DESCRIPTION
## What

- Test matrix: Go 1.25/1.26 → 1.26/1.27
- Build workflows (`custom-build.yml`, `tagpr-release.yml`) and `Dockerfile`: Go 1.26 → 1.27
- `go.mod` is left at `go 1.24.5` since no newer language features are required.

## Why

Go 1.27 has been released; follow the two most recent Go versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoooxNoa1L78HiiYGDLPKW