### PR TITLE
Show embedded aws-sdk-go-v2 module versions

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -39,7 +39,7 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
-	versionFile = -
+	versionFile = version.go
 	release = draft
 	majorLabels = tagpr:major
 	minorLabels = tagpr:minor

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ Flags:
       --camel                     convert keys to camelCase
   -C, --client-option=STRING      client options JSON/Jsonnet struct or filename (e.g. '{UsePathStyle: true}')
   -n, --dry-run                   dry-run mode
-  -v, --version                   show version
+  -v, --version                   show version (with SDK version of the specified service)
+      --sdk-versions              show versions of all embedded AWS SDK modules
       --debug                     turn on debug logging
 ```
 
@@ -197,6 +198,23 @@ Flags:
 - `input`: JSON input for the method.
 
 The output is JSON format.
+
+### Show versions
+
+`awslim -v` shows the version of awslim and the core AWS SDK module (`github.com/aws/aws-sdk-go-v2`). When a service name is given, the version of that service's SDK module embedded in the binary is also shown.
+
+```console
+$ awslim -v
+awslim v0.7.0
+aws-sdk-go-v2 v1.45.1
+
+$ awslim -v s3
+awslim v0.7.0
+aws-sdk-go-v2 v1.45.1
+aws-sdk-go-v2/service/s3 v1.109.1
+```
+
+`awslim --sdk-versions` lists the versions of all `aws-sdk-go-v2` modules embedded in the binary.
 
 All flags can also be set by environment variables prefixed with `AWSLIM_` (e.g., `AWSLIM_COMPACT=true`, `AWSLIM_CLIENT_OPTION='{"UsePathStyle":true}'`).
 

--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,7 @@
 package sdkclient
 
+import "runtime/debug"
+
 var (
 	MarshalJSON = marshalJSON
 )
@@ -18,3 +20,9 @@ func ClientMethods() map[string]map[string]ClientMethod {
 }
 
 type ClientMethodParam = clientMethodParam
+
+func SetBuildInfo(info *debug.BuildInfo) {
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return info, info != nil
+	}
+}

--- a/main.go
+++ b/main.go
@@ -65,9 +65,10 @@ type CLI struct {
 	CamelCase    bool              `name:"camel" help:"convert keys to camelCase"`
 	ClientOption string            `short:"C" help:"client options JSON/Jsonnet struct or filename (e.g. '{UsePathStyle: true}')"`
 
-	DryRun  bool `short:"n" help:"dry-run mode"`
-	Version bool `short:"v" help:"show version"`
-	Debug   bool `help:"turn on debug logging"`
+	DryRun      bool `short:"n" help:"dry-run mode"`
+	Version     bool `short:"v" help:"show version (with SDK version of the specified service)"`
+	SDKVersions bool `name:"sdk-versions" help:"show versions of all embedded AWS SDK modules"`
+	Debug       bool `help:"turn on debug logging"`
 
 	w            io.Writer
 	rc           *RuntimeConfig
@@ -125,8 +126,10 @@ func NewCLI(ctx context.Context, args []string) (*CLI, error) {
 
 func (c *CLI) Dispatch(ctx context.Context) error {
 	if c.Version {
-		fmt.Fprintf(c.w, "awslim %s\n", Version)
-		return nil
+		return c.ShowVersion(ctx)
+	}
+	if c.SDKVersions {
+		return c.ShowSDKVersions(ctx)
 	}
 	if c.Service == "" {
 		return c.ListServices(ctx)

--- a/main.go
+++ b/main.go
@@ -30,8 +30,6 @@ func init() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, opts)))
 }
 
-var Version = "HEAD"
-
 var clientMethods = map[string]map[string]ClientMethod{} // to be defined in main_gen.go
 
 type ClientMethod func(context.Context, *clientMethodParam) (any, error)

--- a/version.go
+++ b/version.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+// Version is the version of awslim. Updated by tagpr, and overridden by -ldflags at build time.
+var Version = "v0.7.0"
+
+// readBuildInfo is replaced in tests.
+var readBuildInfo = debug.ReadBuildInfo
+
 const (
 	sdkModulePrefix        = "github.com/aws/aws-sdk-go-v2"
 	sdkServiceModulePrefix = sdkModulePrefix + "/service/"
@@ -19,7 +25,7 @@ const (
 // (e.g. "" for the core module, "/config", "/service/s3").
 func sdkModuleVersions() map[string]string {
 	versions := map[string]string{}
-	info, ok := debug.ReadBuildInfo()
+	info, ok := readBuildInfo()
 	if !ok {
 		return versions
 	}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,62 @@
+package sdkclient
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"runtime/debug"
+	"slices"
+	"strings"
+)
+
+const (
+	sdkModulePrefix        = "github.com/aws/aws-sdk-go-v2"
+	sdkServiceModulePrefix = sdkModulePrefix + "/service/"
+)
+
+// sdkModuleVersions returns versions of aws-sdk-go-v2 modules embedded in the binary.
+// The keys are module paths without the "github.com/aws/aws-sdk-go-v2" prefix
+// (e.g. "" for the core module, "/config", "/service/s3").
+func sdkModuleVersions() map[string]string {
+	versions := map[string]string{}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return versions
+	}
+	for _, dep := range info.Deps {
+		if dep.Replace != nil {
+			dep = dep.Replace
+		}
+		if dep.Path == sdkModulePrefix || strings.HasPrefix(dep.Path, sdkModulePrefix+"/") {
+			versions[strings.TrimPrefix(dep.Path, sdkModulePrefix)] = dep.Version
+		}
+	}
+	return versions
+}
+
+// ShowVersion prints the version of awslim and the core AWS SDK.
+// If a service is specified, the version of the service module is also printed.
+func (c *CLI) ShowVersion(_ context.Context) error {
+	fmt.Fprintf(c.w, "awslim %s\n", Version)
+	versions := sdkModuleVersions()
+	if v, ok := versions[""]; ok {
+		fmt.Fprintf(c.w, "aws-sdk-go-v2 %s\n", v)
+	}
+	if c.Service != "" {
+		v, ok := versions["/service/"+c.Service]
+		if !ok {
+			return fmt.Errorf("unknown service: %s", c.Service)
+		}
+		fmt.Fprintf(c.w, "aws-sdk-go-v2/service/%s %s\n", c.Service, v)
+	}
+	return nil
+}
+
+// ShowSDKVersions prints versions of all aws-sdk-go-v2 modules embedded in the binary.
+func (c *CLI) ShowSDKVersions(_ context.Context) error {
+	versions := sdkModuleVersions()
+	for _, path := range slices.Sorted(maps.Keys(versions)) {
+		fmt.Fprintf(c.w, "aws-sdk-go-v2%s %s\n", path, versions[path])
+	}
+	return nil
+}

--- a/version_binary_test.go
+++ b/version_binary_test.go
@@ -1,0 +1,90 @@
+package sdkclient_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	sdkclient "github.com/fujiwara/awslim"
+)
+
+// TestVersionBinary builds the real awslim binary and verifies that the SDK
+// versions embedded in its build info are shown. Test binaries built by
+// `go test` do not embed module dependency info on Go 1.26 and earlier, so
+// this cannot be verified in-process.
+func TestVersionBinary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go command not found")
+	}
+	bin := filepath.Join(t.TempDir(), "awslim")
+	build := exec.Command(goBin, "build", "-o", bin, "./cmd/awslim")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build: %v\n%s", err, out)
+	}
+	run := func(args ...string) (string, error) {
+		cmd := exec.Command(bin, args...)
+		cmd.Env = append(os.Environ(), "XDG_CONFIG_HOME=testdata")
+		out, err := cmd.Output()
+		return string(out), err
+	}
+	// expected versions from go.mod
+	modVersion := func(path string) string {
+		out, err := exec.Command(goBin, "list", "-m", "-f", "{{.Version}}", path).Output()
+		if err != nil {
+			t.Fatalf("failed to get version of %s: %v", path, err)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	coreVersion := modVersion("github.com/aws/aws-sdk-go-v2")
+	configVersion := modVersion("github.com/aws/aws-sdk-go-v2/config")
+
+	t.Run("version", func(t *testing.T) {
+		out, err := run("-v")
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect := "awslim " + sdkclient.Version + "\naws-sdk-go-v2 " + coreVersion + "\n"
+		if out != expect {
+			t.Errorf("unexpected output: got %q, expect %q", out, expect)
+		}
+	})
+
+	t.Run("sdk versions", func(t *testing.T) {
+		out, err := run("--sdk-versions")
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		got := map[string]string{}
+		for _, line := range lines {
+			name, version, ok := strings.Cut(line, " ")
+			if !ok {
+				t.Fatalf("unexpected line: %q", line)
+			}
+			got[name] = version
+		}
+		if got["aws-sdk-go-v2"] != coreVersion {
+			t.Errorf("unexpected core version: got %q, expect %q", got["aws-sdk-go-v2"], coreVersion)
+		}
+		if got["aws-sdk-go-v2/config"] != configVersion {
+			t.Errorf("unexpected config version: got %q, expect %q", got["aws-sdk-go-v2/config"], configVersion)
+		}
+		// every module listed must match go.mod
+		for name, version := range got {
+			path := "github.com/aws/" + name
+			if v := modVersion(path); v != version {
+				t.Errorf("unexpected version of %s: got %q, expect %q", path, version, v)
+			}
+		}
+		if !slices.IsSorted(lines) {
+			t.Errorf("output is not sorted: %q", out)
+		}
+	})
+}

--- a/version_test.go
+++ b/version_test.go
@@ -3,68 +3,100 @@ package sdkclient_test
 import (
 	"bytes"
 	"context"
-	"regexp"
-	"strings"
+	"runtime/debug"
 	"testing"
+
+	sdkclient "github.com/fujiwara/awslim"
 )
+
+var testBuildInfo = &debug.BuildInfo{
+	Deps: []*debug.Module{
+		{Path: "github.com/alecthomas/kong", Version: "v1.16.1"},
+		{Path: "github.com/aws/aws-sdk-go-v2", Version: "v1.45.1"},
+		{Path: "github.com/aws/aws-sdk-go-v2/config", Version: "v1.33.1"},
+		{Path: "github.com/aws/aws-sdk-go-v2/service/s3", Version: "v1.109.1"},
+		{Path: "github.com/aws/aws-sdk-go-v2/service/sts", Version: "v1.0.0",
+			Replace: &debug.Module{Path: "github.com/aws/aws-sdk-go-v2/service/sts", Version: "v1.47.1"}},
+		{Path: "github.com/aws/smithy-go", Version: "v1.24.0"},
+	},
+}
 
 func TestVersion(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "testdata")
 	ctx := context.Background()
 
-	t.Run("version", func(t *testing.T) {
-		buf := &bytes.Buffer{}
-		c, err := newCLI(ctx, []string{"-v"}, buf)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := c.Dispatch(ctx); err != nil {
-			t.Fatal(err)
-		}
-		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-		if len(lines) != 2 {
-			t.Fatalf("unexpected output: %q", buf.String())
-		}
-		if lines[0] != "awslim HEAD" {
-			t.Errorf("unexpected awslim version line: %q", lines[0])
-		}
-		if !regexp.MustCompile(`^aws-sdk-go-v2 v\d+\.\d+\.\d+`).MatchString(lines[1]) {
-			t.Errorf("unexpected sdk version line: %q", lines[1])
-		}
-	})
-
-	t.Run("version with unknown service", func(t *testing.T) {
-		buf := &bytes.Buffer{}
-		c, err := newCLI(ctx, []string{"-v", "unknown"}, buf)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := c.Dispatch(ctx); err == nil {
-			t.Fatal("expected error, but got nil")
-		}
-	})
-
-	t.Run("sdk versions", func(t *testing.T) {
-		buf := &bytes.Buffer{}
-		c, err := newCLI(ctx, []string{"--sdk-versions"}, buf)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := c.Dispatch(ctx); err != nil {
-			t.Fatal(err)
-		}
-		re := regexp.MustCompile(`^aws-sdk-go-v2(/\S+)? v\d+\.\d+\.\d+`)
-		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-		if len(lines) < 2 { // at least core and config modules
-			t.Fatalf("unexpected output: %q", buf.String())
-		}
-		for _, line := range lines {
-			if !re.MatchString(line) {
-				t.Errorf("unexpected line: %q", line)
+	cases := []struct {
+		name   string
+		args   []string
+		info   *debug.BuildInfo
+		expect string
+		isErr  bool
+	}{
+		{
+			name:   "version",
+			args:   []string{"-v"},
+			info:   testBuildInfo,
+			expect: "awslim " + sdkclient.Version + "\naws-sdk-go-v2 v1.45.1\n",
+		},
+		{
+			name:   "version with service",
+			args:   []string{"-v", "s3"},
+			info:   testBuildInfo,
+			expect: "awslim " + sdkclient.Version + "\naws-sdk-go-v2 v1.45.1\naws-sdk-go-v2/service/s3 v1.109.1\n",
+		},
+		{
+			name:   "version with replaced service",
+			args:   []string{"-v", "sts"},
+			info:   testBuildInfo,
+			expect: "awslim " + sdkclient.Version + "\naws-sdk-go-v2 v1.45.1\naws-sdk-go-v2/service/sts v1.47.1\n",
+		},
+		{
+			name:   "version with unknown service",
+			args:   []string{"-v", "unknown"},
+			info:   testBuildInfo,
+			expect: "awslim " + sdkclient.Version + "\naws-sdk-go-v2 v1.45.1\n",
+			isErr:  true,
+		},
+		{
+			name:   "version without build info",
+			args:   []string{"-v"},
+			info:   nil,
+			expect: "awslim " + sdkclient.Version + "\n",
+		},
+		{
+			name: "sdk versions",
+			args: []string{"--sdk-versions"},
+			info: testBuildInfo,
+			expect: "aws-sdk-go-v2 v1.45.1\n" +
+				"aws-sdk-go-v2/config v1.33.1\n" +
+				"aws-sdk-go-v2/service/s3 v1.109.1\n" +
+				"aws-sdk-go-v2/service/sts v1.47.1\n",
+		},
+		{
+			name:   "sdk versions without build info",
+			args:   []string{"--sdk-versions"},
+			info:   nil,
+			expect: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sdkclient.SetBuildInfo(tc.info)
+			t.Cleanup(func() { sdkclient.SetBuildInfo(nil) })
+			buf := &bytes.Buffer{}
+			c, err := newCLI(ctx, tc.args, buf)
+			if err != nil {
+				t.Fatal(err)
 			}
-		}
-		if !strings.HasPrefix(lines[0], "aws-sdk-go-v2 v") {
-			t.Errorf("core module must come first: %q", lines[0])
-		}
-	})
+			err = c.Dispatch(ctx)
+			if tc.isErr && err == nil {
+				t.Fatal("expected error, but got nil")
+			} else if !tc.isErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := buf.String(); got != tc.expect {
+				t.Errorf("unexpected output: got %q, expect %q", got, tc.expect)
+			}
+		})
+	}
 }

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,70 @@
+package sdkclient_test
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "testdata")
+	ctx := context.Background()
+
+	t.Run("version", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		c, err := newCLI(ctx, []string{"-v"}, buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Dispatch(ctx); err != nil {
+			t.Fatal(err)
+		}
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		if len(lines) != 2 {
+			t.Fatalf("unexpected output: %q", buf.String())
+		}
+		if lines[0] != "awslim HEAD" {
+			t.Errorf("unexpected awslim version line: %q", lines[0])
+		}
+		if !regexp.MustCompile(`^aws-sdk-go-v2 v\d+\.\d+\.\d+`).MatchString(lines[1]) {
+			t.Errorf("unexpected sdk version line: %q", lines[1])
+		}
+	})
+
+	t.Run("version with unknown service", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		c, err := newCLI(ctx, []string{"-v", "unknown"}, buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Dispatch(ctx); err == nil {
+			t.Fatal("expected error, but got nil")
+		}
+	})
+
+	t.Run("sdk versions", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		c, err := newCLI(ctx, []string{"--sdk-versions"}, buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Dispatch(ctx); err != nil {
+			t.Fatal(err)
+		}
+		re := regexp.MustCompile(`^aws-sdk-go-v2(/\S+)? v\d+\.\d+\.\d+`)
+		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+		if len(lines) < 2 { // at least core and config modules
+			t.Fatalf("unexpected output: %q", buf.String())
+		}
+		for _, line := range lines {
+			if !re.MatchString(line) {
+				t.Errorf("unexpected line: %q", line)
+			}
+		}
+		if !strings.HasPrefix(lines[0], "aws-sdk-go-v2 v") {
+			t.Errorf("core module must come first: %q", lines[0])
+		}
+	})
+}


### PR DESCRIPTION
## What
- `awslim -v` now shows the version of the core `aws-sdk-go-v2` module in addition to the awslim version. When a service is specified (`awslim -v s3`), the version of that service module is also shown.
- Add `--sdk-versions` flag to list versions of all `aws-sdk-go-v2` modules embedded in the binary.
- Move `Version` to `version.go` and set it as the tagpr `versionFile`, so the default version (used when built without `-ldflags`) is kept in sync with releases instead of being `HEAD`.

## Why
Since service wrappers are compiled into the binary, the SDK versions in use were only discoverable via `go version -m`, which requires a Go toolchain. Reading `runtime/debug.ReadBuildInfo()` makes them available from awslim itself without touching the code generator.

Note: test binaries do not embed module dependency info on Go 1.26 and earlier, so in-process tests stub `readBuildInfo` with a fabricated `debug.BuildInfo`, and `TestVersionBinary` builds the real binary and compares its output with `go.mod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uz98MSwzSFaZoGBkD5Zs5Q