### PR TITLE
Document what determines the binary size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,14 @@ Client options (`--client-option`/`-C`, `AWSLIM_CLIENT_OPTION`, or `client_optio
 
 Tests live in the root package as `package sdkclient_test`. `export_test.go` exposes internals (`SetClientMethod`, `ClientMethods`, `ClientMethodParam`). `cli_test.go` registers mock services `foo`, `bar`, `baz` in `init()`, sets `XDG_CONFIG_HOME=testdata` (config in `testdata/awslim/config.yaml`), and uses table-driven cases (`TestCases`) with `Args`, `Env`, `Expect`, `IsError`. Add new CLI behavior as cases there.
 
+## Binary Size
+
+- Size is dominated by per-API serializer/deserializer code in the SDK service packages, so it scales with the number of methods included, not with anything in awslim itself. Measured (linux/amd64, `-s -w`): `sts` only 16MB (baseline), `ec2` all methods +30MB, ec2 limited to 2 methods ≈ baseline, all services ≈ 500MB.
+- The only effective reduction is restricting methods in `gen.yaml`: unreferenced methods are dead-code-eliminated by the linker. `-trimpath` has no effect; `-s -w` is already applied.
+- UPX is not an option for the all-services binary: decompression time scales linearly with size (≈80ms per 46MB with default settings, ≈330ms with `--best --lzma`), so it would add over a second to startup, plus the whole image is held in memory. It also has issues on macOS.
+- A large binary does not start slower by itself (pages are loaded lazily via mmap); the cost is download/disk size only.
+- To inspect what contributes to size: `go build -o awslim ./cmd/awslim` (without `-s -w`) then `go tool nm -size -sort size awslim`. Ignore `B` (BSS) symbols such as `crypto/internal/fips140/drbg.memory`; they do not occupy file space.
+
 ## Release & Maintenance
 
 - `.goreleaser.yml`: release configuration (linux/darwin × amd64/arm64), `Dockerfile` / `build-in-docker.sh` for custom builds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Tests live in the root package as `package sdkclient_test`. `export_test.go` exp
 
 ## Binary Size
 
-- Size is dominated by per-API serializer/deserializer code in the SDK service packages, so it scales with the number of methods included, not with anything in awslim itself. Measured (linux/amd64, `-s -w`): `sts` only 16MB (baseline), `ec2` all methods +30MB, ec2 limited to 2 methods ≈ baseline, all services ≈ 500MB.
+- Size is dominated by per-API serializer/deserializer code in the SDK service packages, so it scales with the number of methods included, not with anything in awslim itself. Measured (linux/amd64, `-s -w`): `sts` only 16MB (baseline), `ec2` all methods +30MB, ec2 limited to 2 methods ≈ baseline, all services (423) ≈ 640MB.
 - The only effective reduction is restricting methods in `gen.yaml`: unreferenced methods are dead-code-eliminated by the linker. `-trimpath` has no effect; `-s -w` is already applied.
 - UPX is not an option for the all-services binary: decompression time scales linearly with size (≈80ms per 46MB with default settings, ≈330ms with `--best --lzma`), so it would add over a second to startup, plus the whole image is held in memory. It also has issues on macOS.
 - A large binary does not start slower by itself (pages are loaded lazily via mmap); the cost is download/disk size only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,13 @@ Tests live in the root package as `package sdkclient_test`. `export_test.go` exp
 - A large binary does not start slower by itself (pages are loaded lazily via mmap); the cost is download/disk size only.
 - To inspect what contributes to size: `go build -o awslim ./cmd/awslim` (without `-s -w`) then `go tool nm -size -sort size awslim`. Ignore `B` (BSS) symbols such as `crypto/internal/fips140/drbg.memory`; they do not occupy file space.
 
+### Startup Cost (all-services binary)
+
+- Measured with `GODEBUG=inittrace=1`: 1,083 packages are initialized, taking ~67ms and allocating ~55MB on the heap. This is essentially all of the ~100ms startup delay and most of the ~170MB max RSS (the rest is binary pages touched during init).
+- The cost is in SDK package `init`, not in awslim: `service/*/internal/endpoints` (423 pkgs, ~29MB, ~70KB each) and `service/*/schemas` (109 pkgs, ~25MB, up to 900KB each) build map-containing composite literals at init, which cannot be laid out statically. The service root packages (~0.1MB) and awslim's own method map (~0.9MB) are negligible. `GOGC=off` makes no difference.
+- Lazy initialization per service is not possible in-process: Go always runs `init` of every linked package. Deferring it would require not linking the service packages (Go plugins, or separate binaries with an exec dispatcher), which breaks the single static binary and costs more in size/complexity than the ~60ms/~120MB it saves. The only lever in awslim is building with fewer services.
+- Inspect with: `GODEBUG=inittrace=1 ./awslim -v 2>&1 >/dev/null | sort -k8 -n -r | head` (columns: init time in ms at $5, bytes allocated at $8).
+
 ## Release & Maintenance
 
 - `.goreleaser.yml`: release configuration (linux/darwin × amd64/arm64), `Dockerfile` / `build-in-docker.sh` for custom builds.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ services:
 
 Keys under `services` are AWS service names (`github.com/aws/aws-sdk-go-v2/service/*`), and values are method names of the service client (for example, `s3` is [s3.Client](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client)). If you don't specify the method names, all methods of the service client are generated.
 
+### Binary size
+
+The binary size is dominated by the SDK code for each API (request serializers and response deserializers), so it grows roughly in proportion to the number of methods included. Methods that are not listed in `gen.yaml` are removed by the Go linker.
+
+Examples (linux/amd64):
+
+| Services | Size |
+|---|---|
+| `sts` only (baseline) | 16MB |
+| `ec2` with 2 methods | 17MB |
+| `ec2` with all methods | 46MB |
+| All services | about 500MB |
+
+To get a small binary, list only the methods you need in `gen.yaml`. Note that a large binary does not start noticeably slower, since only the pages actually used are loaded; the cost of a large binary is download and disk space.
+
 ### Build binary for specified OS/Architecture
 
 Set the `AWSLIM_OS` and `AWSLIM_ARCH` environment variables to specify the OS and architecture for the build.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ While the [AWS CLI](https://aws.amazon.com/cli/) is very useful, it can be resou
 
 ## Installation
 
-**Note:** The release binaries are large (about 500MB after being extracted) and have a slight startup delay (about 100ms), due to the inclusion of code to access **[all AWS services](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service)**. However, it is still [faster](#performance-comparison) than the AWS CLI.
+**Note:** The release binaries are large (about 640MB after being extracted) and have a slight startup delay (about 100ms), due to the inclusion of code to access **[all AWS services](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service)**. However, it is still [faster](#performance-comparison) than the AWS CLI.
 
 For optimized performance, build your own binary tailored to the specific services you need. See the [Build](#build) section for details.
 
@@ -86,7 +86,7 @@ Examples (linux/amd64):
 | `sts` only (baseline) | 16MB |
 | `ec2` with 2 methods | 17MB |
 | `ec2` with all methods | 46MB |
-| All services | about 500MB |
+| All services (423) | 642MB |
 
 To get a small binary, list only the methods you need in `gen.yaml`. Note that a large binary does not start noticeably slower, since only the pages actually used are loaded; the cost of a large binary is download and disk space.
 
@@ -155,7 +155,7 @@ Run `./build-in-docker.sh` in the container to build the client. The built binar
 ```Dockerfile
 FROM ghcr.io/fujiwara/awslim:builder AS builder
 ENV AWSLIM_GEN=ecs,firehose,s3
-ENV GIT_REF=v0.3.0
+ENV GIT_REF=v0.7.0
 RUN ./build-in-docker.sh
 
 FROM debian:bookworm-slim
@@ -164,18 +164,18 @@ COPY --from=builder /app/awslim /usr/local/bin/awslim
 
 ## Performance comparison
 
-Example of executing `sts get-caller-identity` on a 0.25 vCPU Fargate(AMD64) using `/usr/bin/time -v` for time measurement.
+Example of executing `sts get-caller-identity` on a Linux desktop (AMD Ryzen 7 255, 16 cores), measured with `/usr/bin/time` (median of 5 runs).
 
 | command | CPU time(user, sys)| Elapsed time(s) | Max memory(MB) | Size(MB) |
 | ---- | ---- | ---- | --- | --- |
-| aws         | 0.67 + 0.10 = 0.77 | 3.11 | 64.2  | 225 |
-| awslim(all) | 0.08 + 0.03 = 0.11 | 0.43 | 101.5 | 476 |
-| awslim(40)  | 0.02 + 0.01 = 0.03 | 0.05 | 30.2  |  95 |
+| aws         | 0.52 + 0.09 = 0.61 | 0.68 | 83.8  | 326 |
+| awslim(all) | 0.08 + 0.07 = 0.15 | 0.14 | 171.2 | 642 |
+| awslim(40)  | 0.01 + 0.02 = 0.03 | 0.06 | 42.4  | 153 |
 
-- `awslim`(built for all AWS services): 7.0x faster than `aws`
-- `awslim`(built for 40 AWS services): 62.0x faster than `aws`
+- `awslim`(built for all 423 AWS services): 4.9x faster than `aws`
+- `awslim`(built for 40 AWS services): 11.3x faster than `aws`
 
-`aws-cli/2.15.51 Python/3.11.8`, `awslim 0.1.0`
+`aws-cli/2.34.28 Python/3.14.3`, `awslim v0.7.0`. Elapsed time includes the network round trip to the STS API, so the difference in CPU time is more representative of the startup cost.
 
 ## Usage
 


### PR DESCRIPTION
## What
- README: add a "Binary size" section under Build with measured sizes and an explanation of why restricting methods in `gen.yaml` is what actually shrinks the binary.
- README: re-measure the performance comparison with awslim v0.7.0 / aws-cli 2.34.28 (it was measured with awslim 0.1.0), and update stale sizes (the all-services binary is now about 640MB) and the `GIT_REF` example.
- CLAUDE.md: record the size analysis (what dominates, what works, why UPX is not an option for the all-services binary, how to inspect) and the startup cost analysis (SDK package init of endpoints/schemas dominates; lazy init per service is not possible in-process).

## Why
The all-services binary is about 640MB. The size comes from per-API serializer/deserializer code in the SDK, and the only effective reduction is limiting methods so the linker can drop the rest. Writing this down avoids re-investigating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uz98MSwzSFaZoGBkD5Zs5Q